### PR TITLE
Fix logout not clearing session on WindowFix logout not clearing session on Windows (client.destroy before folder deletion)s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2421,7 +2421,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
### Summary

This PR fixes an issue where logging out on Windows did not fully clear the WhatsApp session.  
Even after clicking logout and restarting the project, the previous WhatsApp chats would still load automatically.

### Problem

On Windows, the file `.wwebjs_auth/session/Default/chrome_debug.log` is locked by Puppeteer while the WhatsApp client is running.  
Because of this:

- `.wwebjs_auth` could not be deleted completely
- LocalAuth session persisted
- WhatsApp auto-logged in again after restart
- Users could not fully logout

Logout looked successful but the session was still present.

### Root Cause

`fs.rmSync` tried to delete the session folder **before** the WhatsApp client had been destroyed.  
Windows prevents deleting locked files, resulting in an incomplete session cleanup.

### Fix

1. **Call `client.destroy()` before deleting session folders**
   - Ensures Puppeteer closes
   - Releases the locked `chrome_debug.log`
   - Allows full removal of `.wwebjs_auth` and `.wwebjs_cache`

2. **Delete both folders after destroy**
   - Ensures no old session is left behind

3. Removed the forced `process.exit(0)` behavior to enable UI return to home page without stopping the backend.

### Result

- Logout now fully clears the WhatsApp session on Windows.
- Restarting the project correctly shows the QR code again.
- No auto-login occurs.
- Works consistently across restarts.

### Tested On

- Windows 10  
- Node.js environment  
- WhatsApp Web.js with LocalAuth

### Additional Notes

The console warning:

`Protocol error: Session closed. Most likely the page has been closed.`

is expected because the WhatsApp client is terminated during logout. 
It does not affect functionality and is normal for WhatsApp Web.js applications.

---

Please review and merge. 🙌
